### PR TITLE
refactor: no config passing

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const fs = require("fs");
 
 Log.info(`Starting Log Processing ${Config.LOGS_DIR}`, { domain: DOMAIN });
 LogsParser.parseLogFiles();
-Log.verbose(`Starting jarfile data extractor`, {domain: DOMAIN});
+Log.verbose(`Starting jarfile data extractor`, { domain: DOMAIN });
 ServerDataExtractor.checkForData();
 
 /**

--- a/index.js
+++ b/index.js
@@ -19,10 +19,10 @@ Log.verbose("Finish requiring of lib.", { domain: DOMAIN });
 const path = require("path");
 const fs = require("fs");
 
-Log.debug("Passing configuration to components.", { domain: DOMAIN });
-ServerDataExtractor.setConfig(Config);
 Log.info(`Starting Log Processing ${Config.LOGS_DIR}`, { domain: DOMAIN });
-LogsParser.parseLogFiles(Config);
+LogsParser.parseLogFiles();
+Log.verbose(`Starting jarfile data extractor`, {domain: DOMAIN});
+ServerDataExtractor.checkForData();
 
 /**
  * @return {Promise}

--- a/lib/LogsParser.js
+++ b/lib/LogsParser.js
@@ -1,10 +1,12 @@
+const config = require('./Configuration');
+const log = config.logger;
+const logconst = require("./helpers/LogConst");
+const logregx = require("./helpers/LogsRegex");
+
 const zlib = require("zlib");
 const fs = require("fs");
 const path = require("path");
 const readline = require("readline");
-const log = require("./Configuration").logger;
-const logconst = require("./helpers/LogConst");
-const logregx = require("./helpers/LogsRegex");
 
 const DOMAIN = "LogParser";
 let logfiles = [];
@@ -195,9 +197,8 @@ function jsonFromLogfilePromise(filepath) {
 
 /**
  * Prepare log files, unzip gzip files so we can parse in one pass.
- * @param {object} config
  */
-function prepareLogFiles(config) {
+function prepareLogFiles() {
   const rawLogFiles = fs.readdirSync(config.LOGS_DIR);
 
   log.debug(`Preparing following log files: ${JSON.stringify(rawLogFiles)}`, { domain: DOMAIN });
@@ -227,10 +228,9 @@ function prepareLogFiles(config) {
 
 /**
  * parses all log files
- * @param {object} config
  */
-function parseLogFiles(config) {
-  prepareLogFiles(config);
+function parseLogFiles() {
+  prepareLogFiles();
   const tmplogPath = path.join(config.TEMP_DIR, "all_logs.json");
   log.debug("Beginning parse of all log files.", { domain: DOMAIN });
   const createJsonPromises = [];

--- a/lib/LogsParser.js
+++ b/lib/LogsParser.js
@@ -1,4 +1,4 @@
-const config = require('./Configuration');
+const config = require("./Configuration");
 const log = config.logger;
 const logconst = require("./helpers/LogConst");
 const logregx = require("./helpers/LogsRegex");

--- a/lib/ServerDataTool.js
+++ b/lib/ServerDataTool.js
@@ -5,11 +5,10 @@
 const fs = require("fs");
 const path = require("path");
 const childp = require("child_process");
-const log = require("./Configuration").logger;
+const config = require('./Configuration');
+const log = config.logger;
 
 const DOMAIN = "DataExtrator";
-let tempRoot = "unset";
-let serverjarPath = "unset";
 let advancementsExported = false;
 let loottablesExported = false;
 let recipesExported = false;
@@ -30,17 +29,17 @@ function checkForData() {
   blocklistExported = false;
   commandlistExported = false;
   registriesExported = false;
-  if (fs.existsSync(path.join(tempRoot, "data"))) {
-    if (fs.existsSync(path.join(tempRoot, "data", "minecraft"))) {
-      advancementsExported = fs.existsSync(path.join(tempRoot, "data", "minecraft", "advancements"));
-      loottablesExported = fs.existsSync(path.join(tempRoot, "data", "minecraft", "loot_tables"));
-      recipesExported = fs.existsSync(path.join(tempRoot, "data", "minecraft", "recipes"));
-      tagsExported = fs.existsSync(path.join(tempRoot, "data", "minecraft", "tags"));
+  if (fs.existsSync(path.join(config.TEMP_DIR, "data"))) {
+    if (fs.existsSync(path.join(config.TEMP_DIR, "data", "minecraft"))) {
+      advancementsExported = fs.existsSync(path.join(config.TEMP_DIR, "data", "minecraft", "advancements"));
+      loottablesExported = fs.existsSync(path.join(config.TEMP_DIR, "data", "minecraft", "loot_tables"));
+      recipesExported = fs.existsSync(path.join(config.TEMP_DIR, "data", "minecraft", "recipes"));
+      tagsExported = fs.existsSync(path.join(config.TEMP_DIR, "data", "minecraft", "tags"));
     }
-    if (fs.existsSync(path.join(tempRoot, "data", "reports"))) {
-      blocklistExported = fs.existsSync(path.join(tempRoot, "data", "reports", "blocks.json"));
-      blocklistExported = fs.existsSync(path.join(tempRoot, "data", "reports", "commands.json"));
-      blocklistExported = fs.existsSync(path.join(tempRoot, "data", "reports", "registries.json"));
+    if (fs.existsSync(path.join(config.TEMP_DIR, "data", "reports"))) {
+      blocklistExported = fs.existsSync(path.join(config.TEMP_DIR, "data", "reports", "blocks.json"));
+      blocklistExported = fs.existsSync(path.join(config.TEMP_DIR, "data", "reports", "commands.json"));
+      blocklistExported = fs.existsSync(path.join(config.TEMP_DIR, "data", "reports", "registries.json"));
     }
   }
   log.debug(`advancements data is cached: ${advancementsExported}`, { domain: DOMAIN });
@@ -59,13 +58,8 @@ function checkForData() {
 function exportMinecraftDataPromise() {
   return new Promise((resolve, reject) => {
     log.verbose("Running minecraft data export from server jar.", { domain: DOMAIN });
-    if (tempRoot === "unset" || serverjarPath === "unset") {
-      log.error("Tried to run data generation without setting serverjar and/or output folder.", { domain: DOMAIN });
-      log.error(`datadir: ${tempRoot}, serverjar: ${serverjarPath}`, { domain: DOMAIN });
-      reject(new Error("Failed to set directories."));
-    }
     childp.exec(
-      `java -cp ${serverjarPath} net.minecraft.data.Main --all --output ${tempRoot}`,
+      `java -cp ${config.MCJAR_FILE} net.minecraft.data.Main --all --output ${config.TEMP_DIR}`,
       (err, stdout, stderr) => {
         // eslint-disable-line
         if (err) {
@@ -92,23 +86,13 @@ function ensureMinecraftAdvancements() {
       log.debug(val, { domain: DOMAIN });
     });
   } else {
-    log.info(`Using cached minecraft advancements in ${path.join(tempRoot, "data", "minecraft", "advancements")}`, {
+    log.info(`Using cached minecraft advancements in ${path.join(config.TEMP_DIR, "data", "minecraft", "advancements")}`, {
       domain: DOMAIN,
     });
   }
 }
 
-/**
- * Keeps things set to one configuration instance *
- * @param {object} config
- */
-function setConfig(config) {
-  tempRoot = config.TEMP_DIR;
-  serverjarPath = config.MCJAR_FILE;
-  checkForData();
-}
-
 module.exports = {
+  checkForData,
   ensureMinecraftAdvancements,
-  setConfig,
 };

--- a/lib/ServerDataTool.js
+++ b/lib/ServerDataTool.js
@@ -5,7 +5,7 @@
 const fs = require("fs");
 const path = require("path");
 const childp = require("child_process");
-const config = require('./Configuration');
+const config = require("./Configuration");
 const log = config.logger;
 
 const DOMAIN = "DataExtrator";
@@ -86,9 +86,12 @@ function ensureMinecraftAdvancements() {
       log.debug(val, { domain: DOMAIN });
     });
   } else {
-    log.info(`Using cached minecraft advancements in ${path.join(config.TEMP_DIR, "data", "minecraft", "advancements")}`, {
-      domain: DOMAIN,
-    });
+    log.info(
+      `Using cached minecraft advancements in ${path.join(config.TEMP_DIR, "data", "minecraft", "advancements")}`,
+      {
+        domain: DOMAIN,
+      }
+    );
   }
 }
 


### PR DESCRIPTION
For consistency, have all library code get their own configuration.